### PR TITLE
Update chainparams.cpp

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -486,7 +486,7 @@ public:
         consensus.nCollaterals = SmartnodeCollaterals(
 			{
 				{88720, 60000 * COIN}, {132720, 800000 * COIN}, {176720, 1000000 * COIN}, {220720, 1250000 * COIN},
-				{264720, 1500000 * COIN}, {308720, 1800000 * COIN}
+				{264720, 1500000 * COIN}, {INT_MAX, 1800000 * COIN}
 			},
 			{
 				{5761, 0}, {INT_MAX, 20}


### PR DESCRIPTION
last smartnode collateral of 1800000 as defined in chainparams.cpp:488 ff. was set to end at height 308720. following that height the smartnode collateral was undefined and in conclusion leaving the smartnode network disfunct.
replacing 308720 with MAX_INT validates the last collateral for smartnodes up to the maximum blockheight possible.