### PR TITLE
Decode Block Scrypt bug Added return thash; at line 56

### DIFF
--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -55,7 +55,7 @@ uint256 CBlockHeader::GetPOWHash(int algo) const
         case ALGO_SCRYPT:
         default:
             scrypt_1024_1_1_256(BEGIN(nVersion), BEGIN(thash));
-
+            return thash;
     }
     return GetHash();
 }


### PR DESCRIPTION
 Scrypt - Block cant be decoded #15 issue

1. \but\src\primitives\block.cpp at line 58 added, return thash; that was missing